### PR TITLE
Validation creation improvements

### DIFF
--- a/src/main/scala/api/BaseApi.scala
+++ b/src/main/scala/api/BaseApi.scala
@@ -24,7 +24,7 @@ trait BaseApi extends ServiceHolder with JsonMappings {
 
   def findAuctionOrNotFound(id: AuctionId)(auctionTransformer: Auction => StandardRoute): StandardRoute = {
     service.getAuction(id) match {
-      case Some(auction) => auctionTransformer(auction)
+      case Success(auction) => auctionTransformer(auction)
       case _ => complete(StatusCodes.NotFound)
     }
   }

--- a/src/main/scala/api/InputValidator.scala
+++ b/src/main/scala/api/InputValidator.scala
@@ -19,19 +19,25 @@ object InputValidator {
   val lotDataErrorMsg = "Lot data cannot be empty."
   val limitErrorMsg = "Limit should be a value between 0 and 100 (right inclusive)."
   val offsetErrorMsg = "Offset should be a value greater than 0."
+
+  val defaultUUIDErrorMsg = "Invalid UUID string."
+  val defaultDataErrorMsg = "Data cannot be empty."
 }
 
 trait InputValidator {
 
   import InputValidator._
 
-  def validUUIDString(uuid: String): Option[String] = Try(UUID.fromString(uuid).toString).toOption
+  def uuid(stringUUID: String, errorMessage: String = defaultUUIDErrorMsg): VNel[UUID] = Try(UUID.fromString(stringUUID)).toOption.toSuccessNel(errorMessage)
 
-  def validData(data: String): Option[String] = if (data.trim.length > 0) Some(data) else None
+  def validData(data: String, errorMessage: String = defaultDataErrorMsg): VNel[String] = {
+    val maybeData = if (data.trim.length > 0) Some(data) else None
+    maybeData.toSuccessNel(errorMessage)
+  }
 
   def validateGetLotsInput(input: LotsApi.LimitedResultRequest[AuctionId]): VNel[LimitedResultRequest[AuctionId]] = {
     Apply[VNel].apply(
-      validUUIDString(input.resourceId).toSuccessNel(auctionIdErrorMsg)
+      uuid(input.resourceId, auctionIdErrorMsg)
     ) {
       _ => input
     }

--- a/src/main/scala/persistence/AuctionService.scala
+++ b/src/main/scala/persistence/AuctionService.scala
@@ -8,7 +8,7 @@ case class LimitedResult[T](items: Seq[T], limit: Int, offset: Int, total: Int)
 trait AuctionService {
   def createAuction(data: AuctionData): VNel[AuctionId]
 
-  def getAuction(id: AuctionId): Option[Auction]
+  def getAuction(id: AuctionId): VNel[Auction]
 
   def addLot(auctionId: AuctionId, data: LotData): VNel[LotId]
 

--- a/src/main/scala/persistence/MemStorage.scala
+++ b/src/main/scala/persistence/MemStorage.scala
@@ -39,12 +39,9 @@ class MemStorage extends AuctionService with InputValidator {
   override def getAuction(id: AuctionId): VNel[Auction] = auctions.find( _.id == id).toSuccessNel(auctionNotFoundErrorMsg)
 
   override def addLot(auctionId: AuctionId, data: LotData): VNel[LotId] = {
-    newLot(auctionId, data) match {
-      case Success(lot) => {
-        lots :+= lot
-        Success(lot.id)
-      }
-      case Failure(errors) => Failure(errors)
+    newLot(auctionId, data) map { lot =>
+      lots :+= lot
+      lot.id
     }
   }
 
@@ -59,13 +56,10 @@ class MemStorage extends AuctionService with InputValidator {
 
   private def newUUIDString: String = UUID.randomUUID.toString
 
-  private def newLot(auctionId: AuctionId, data: LotData): VNel[Lot] = {
-    ((uuid(auctionId, auctionIdErrorMsg) andThen findAuction) |@| validData(data, lotDataErrorMsg)) {
-      (_, _) => {
-        Lot(newUUIDString, auctionId, data)
-      }
+  private def newLot(auctionId: AuctionId, data: LotData): VNel[Lot] =
+    ((uuid(auctionId, auctionIdErrorMsg) andThen findAuction) |@| validData(data, lotDataErrorMsg)) { (_, _) =>
+      Lot(newUUIDString, auctionId, data)
     }
-  }
 
   private def findAuction(uuid: UUID): VNel[Auction] = {
     val stringUUID = uuid.toString

--- a/src/test/scala/LotsApiSpec.scala
+++ b/src/test/scala/LotsApiSpec.scala
@@ -112,11 +112,24 @@ class LotsApiSpec extends WordSpec with Matchers with ScalatestRouteTest with Ro
         status shouldEqual StatusCodes.BadRequest
 
         val errors = responseAs[ErrorResponseMessage]._embedded
-        errors.length shouldBe 3
+        errors.length shouldBe 2
 
         errors(0).message shouldEqual "Invalid auction Id. Please provide a valid UUID."
-        errors(1).message shouldEqual "Invalid auction Id. Auction does not exist."
-        errors(2).message shouldEqual "Lot data cannot be empty."
+        errors(1).message shouldEqual "Lot data cannot be empty."
+      }
+    }
+
+    "return 400 with error given not existing auction UUID" in {
+      val entity = HttpEntity(MediaTypes.`application/json`,
+        "{\"auctionId\": \"111772c5-bc52-4d3c-ba9e-4010f511e175\", \"lotData\": \"test\"}")
+
+      Post("/lots").withEntity(entity) ~> lotsApi ~> check {
+        status shouldEqual StatusCodes.BadRequest
+
+        val errors = responseAs[ErrorResponseMessage]._embedded
+        errors.length shouldBe 1
+
+        errors(0).message shouldEqual "Invalid auction Id. Auction does not exist."
       }
     }
   }


### PR DESCRIPTION
Z ta walidacja, to mniej wiecej juz rozumiem na jakiej zasadzie to dziala od kiedy zaimplementowalem pierwsza wersje. Brakowalo mi po prostu operatora, ktory mi zchainuje te operacje elegancko. Probowalem sie bawic z `|||`, `~`, `@\/` ale zawsze cos albo nie dzialalo albo nie wygladalo dobrze. Teraz zrobilem tak `(uuid(auctionId, auctionIdErrorMsg) andThen findAuction)` plus dalej jeszcze `|@|` i to dziala jak nalezy i wyglada tez odpowiednio.  Zmienilem wszystkie metody walidacyjne, aby zwracaly `VNel[A]`, bo wtedy tez mozna te walidacje elegancko laczyc, tak jak tu przed chwila wkleilem.

Tez wylaczylem kod do metody `def newLot(auctionId: AuctionId, data: LotData): VNel[Lot]`. Chociaz poki co API wyglada bardzo podobnie, a ta metoda jest tylko prywatna metoda. Byc moze nie do konca o to Tobie chodzilo, ale mysle, ze to tez bedzie inaczej wygladalo, jesli mielibysmy pomiedzy API i Storage jeszcze taki layer `LotsDAO` albo cos w ten desen. Mi sie zawsze najbardziej podoba jak taka zewnetrzna warstwa jak `LotsAPI` nie ma pojecia o zlozonosci i najlepiej wywoluje tylko jedna metode, a cala zlozonosc jest ukryta, np. w warstwie `DAO` (tutaj tej warstwy jeszcze nie ma, wiec wszystko dzieje sie w `Storage`.). Tym samym mozna ja latwo ponownie uzywac podczas innych scenariuszy. 
