### PR TITLE
use UUIDs instead of string ids

### DIFF
--- a/src/main/scala/api/AuctionsApi.scala
+++ b/src/main/scala/api/AuctionsApi.scala
@@ -4,16 +4,12 @@ import java.util.UUID
 
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import api.AuctionsApi.{GetInput, PostInput}
-import entities.{AuctionData, AuctionId}
+import api.AuctionsApi.{PostInput}
+import entities.{AuctionData}
 import mappings.JsonMappings
 
-import scala.util.Try
-
 object AuctionsApi {
-  case class GetInput(id: AuctionId) {
-    require(Try(UUID.fromString(id).toString).isSuccess, "Invalid auction Id. Auction Id must have a UUID format.")
-  }
+  case class GetInput(id: UUID)
   case class PostInput(data: AuctionData)
 }
 
@@ -27,8 +23,8 @@ trait AuctionsApi extends JsonMappings with ServiceHolder with BaseApi with Inpu
         }
       }
     } ~
-      path(Segment).as(GetInput) { input =>
-        findAuctionOrNotFound(input.id) { auction =>
+      path(JavaUUID) { id =>
+        findAuctionOrNotFound(id) { auction =>
           complete(auction)
         }
       }

--- a/src/main/scala/api/BaseApi.scala
+++ b/src/main/scala/api/BaseApi.scala
@@ -1,18 +1,27 @@
 package api
 
+import java.util.UUID
+
 import akka.http.scaladsl.marshalling.{Marshaller, Marshalling, ToEntityMarshaller, ToResponseMarshaller}
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.server.Directives.complete
 import akka.http.scaladsl.server.StandardRoute
 import api.InputValidator.{ErrorMsg, VNel}
-import entities.{Auction, AuctionId, LotId}
+import entities.Auction
 import mappings.JsonMappings
+
 import scala.concurrent.Future
 import scalaz._
 import Scalaz._
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import spray.json.{DeserializationException}
+
+import scala.util.Try
 
 trait BaseApi extends ServiceHolder with JsonMappings {
+
+  implicit def uuidToEntityMarshaller: ToEntityMarshaller[UUID] = Marshaller.stringMarshaller(MediaTypes.`application/json`).compose( _.toString )
 
   def errorsListMarshaller: ToResponseMarshaller[NonEmptyList[ErrorMsg]] =
     Marshaller { _ =>
@@ -30,7 +39,15 @@ trait BaseApi extends ServiceHolder with JsonMappings {
       }
     }
 
-  def findAuctionOrNotFound(id: AuctionId)(auctionTransformer: Auction => StandardRoute): StandardRoute = {
+  implicit val uuidFromStringUnmarshaller: Unmarshaller[String, UUID] =
+    Unmarshaller.strict[String, UUID](stringFromUUID)
+
+  private def stringFromUUID(s: String): UUID = Try(UUID.fromString(s)) match {
+    case scala.util.Success(uuid) => uuid
+    case _ => throw new DeserializationException(s"'$s' is not a valid UUID")
+  }
+
+  def findAuctionOrNotFound(id: UUID)(auctionTransformer: Auction => StandardRoute): StandardRoute = {
     service.getAuction(id) match {
       case Success(auction) => auctionTransformer(auction)
       case _ => complete(StatusCodes.NotFound)

--- a/src/main/scala/api/InputValidator.scala
+++ b/src/main/scala/api/InputValidator.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 import scalaz._
 import Scalaz._
 import api.LotsApi.{LimitedResultRequest}
-import entities.AuctionId
 
 import scala.util.Try
 
@@ -28,18 +27,8 @@ trait InputValidator {
 
   import InputValidator._
 
-  def uuid(stringUUID: String, errorMessage: String = defaultUUIDErrorMsg): VNel[UUID] = Try(UUID.fromString(stringUUID)).toOption.toSuccessNel(errorMessage)
-
   def validData(data: String, errorMessage: String = defaultDataErrorMsg): VNel[String] = {
     val maybeData = if (data.trim.length > 0) Some(data) else None
     maybeData.toSuccessNel(errorMessage)
-  }
-
-  def validateGetLotsInput(input: LotsApi.LimitedResultRequest[AuctionId]): VNel[LimitedResultRequest[AuctionId]] = {
-    Apply[VNel].apply(
-      uuid(input.resourceId, auctionIdErrorMsg)
-    ) {
-      _ => input
-    }
   }
 }

--- a/src/main/scala/api/LotsApi.scala
+++ b/src/main/scala/api/LotsApi.scala
@@ -1,13 +1,19 @@
 package api
 
+import java.util.UUID
+
+import akka.http.javadsl.unmarshalling.StringUnmarshaller
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.unmarshalling.Unmarshaller
 import api.LotsApi.{LimitedResultRequest, PostInput}
-import entities.{AuctionId, LotData}
+import entities.LotData
 import mappings.JsonMappings
 
+import scala.util.{Success, Try}
+
 object LotsApi {
-  case class PostInput(auctionId: AuctionId, lotData: LotData)
+  case class PostInput(auctionId: UUID, lotData: LotData)
 
   case class LimitedResultRequest[T](resourceId: T, limit: Option[Int], offset: Option[Int]) {
     require(
@@ -34,12 +40,10 @@ trait LotsApi extends BaseApi with JsonMappings with InputValidator {
           complete(service.addLot(input.auctionId, input.lotData))
         }
       } ~
-      parameters('auctionId, 'limit.as[Int].?, 'offset.as[Int].?).as(LimitedResultRequest[AuctionId]) { input =>
+      parameters('auctionId.as[UUID], 'limit.as[Int].?, 'offset.as[Int].?).as(LimitedResultRequest[UUID]) { input =>
 
-        validDataOrErrorResponse(input)(validateGetLotsInput) { input =>
-          findAuctionOrNotFound(input.resourceId) { auction =>
-            complete(service.getLots(auction.id, input.limit, input.offset))
-          }
+        findAuctionOrNotFound(input.resourceId) { auction =>
+          complete(service.getLots(auction.id, input.limit, input.offset))
         }
 
       }

--- a/src/main/scala/entities/entities.scala
+++ b/src/main/scala/entities/entities.scala
@@ -1,4 +1,6 @@
 package entities
 
-case class Auction(id: AuctionId, data: AuctionData)
-case class Lot(id: LotId, auctionId: AuctionId, data: LotData)
+import java.util.UUID
+
+case class Auction(id: UUID, data: AuctionData)
+case class Lot(id: UUID, auctionId: UUID, data: LotData)

--- a/src/main/scala/entities/package.scala
+++ b/src/main/scala/entities/package.scala
@@ -1,6 +1,5 @@
+
 package object entities {
-  type LotId = String
   type LotData = String
-  type AuctionId = String
   type AuctionData = String
 }

--- a/src/main/scala/extensions/StringExtensions.scala
+++ b/src/main/scala/extensions/StringExtensions.scala
@@ -1,0 +1,9 @@
+package extensions
+
+import java.util.UUID
+
+object StringExtensions {
+  implicit class StringExtensions(val s: String) {
+    def uuid = UUID.fromString(s) //TODO: make safe!
+  }
+}

--- a/src/main/scala/mappings/JsonMappings.scala
+++ b/src/main/scala/mappings/JsonMappings.scala
@@ -1,14 +1,27 @@
 package mappings
 
+import java.util.UUID
+
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import entities._
 import persistence.LimitedResult
-import spray.json.DefaultJsonProtocol
+import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat}
 import api.AuctionsApi
 import api.ErrorResponse.{ErrorMessage, ErrorResponseMessage}
 import api.LotsApi
 
+import scala.util.Try
+
 trait JsonMappings extends SprayJsonSupport with DefaultJsonProtocol {
+  implicit val uuidFormat = new JsonFormat[UUID] {
+    override def write(obj: UUID): JsValue = JsString(obj.toString)
+
+    override def read(json: JsValue): UUID = json match {
+      case JsString(uuid) => Try(UUID.fromString(uuid)).getOrElse(throw new DeserializationException("Expected UUID format."))
+      case _              => throw new DeserializationException("Expected UUID format.")
+    }
+  }
+
   implicit val auctionPostDataFormat = jsonFormat1(AuctionsApi.PostInput)
   implicit val auctionFormat = jsonFormat2(Auction)
   implicit val lotPostDataFormat = jsonFormat2(LotsApi.PostInput)

--- a/src/main/scala/persistence/AuctionService.scala
+++ b/src/main/scala/persistence/AuctionService.scala
@@ -1,16 +1,18 @@
 package persistence
 
+import java.util.UUID
+
 import api.InputValidator.VNel
 import entities._
 
 case class LimitedResult[T](items: Seq[T], limit: Int, offset: Int, total: Int)
 
 trait AuctionService {
-  def createAuction(data: AuctionData): VNel[AuctionId]
+  def createAuction(data: AuctionData): VNel[UUID]
 
-  def getAuction(id: AuctionId): VNel[Auction]
+  def getAuction(id: UUID): VNel[Auction]
 
-  def addLot(auctionId: AuctionId, data: LotData): VNel[LotId]
+  def addLot(auctionId: UUID, data: LotData): VNel[UUID]
 
-  def getLots(auctionId: AuctionId, limit: Option[Int], offset: Option[Int]): LimitedResult[Lot]
+  def getLots(auctionId: UUID, limit: Option[Int], offset: Option[Int]): LimitedResult[Lot]
 }

--- a/src/main/scala/persistence/MemStorage.scala
+++ b/src/main/scala/persistence/MemStorage.scala
@@ -7,26 +7,26 @@ import scalaz._
 import Scalaz._
 import api.InputValidator
 import api.InputValidator.{VNel, _}
+import extensions.StringExtensions._
 
 class MemStorage extends AuctionService with InputValidator {
   private var auctions = Seq(
-    Auction("4ac772c5-bc52-4d3c-ba9e-4010f511e175", "First"),
-    Auction("0ae024c0-0ddb-4e59-9e2c-721a27c386f6", "Second"),
-    Auction("b9549a8e-be47-4b8b-a38c-226c2647073d", "Third")
+    Auction("4ac772c5-bc52-4d3c-ba9e-4010f511e175".uuid, "First"),
+    Auction("0ae024c0-0ddb-4e59-9e2c-721a27c386f6".uuid, "Second"),
+    Auction("b9549a8e-be47-4b8b-a38c-226c2647073d".uuid, "Third")
   )
 
   private var lots = Seq(
-    Lot("6b2e9336-7911-4381-a0e7-382a4e510291", "4ac772c5-bc52-4d3c-ba9e-4010f511e175", "Lot 1 for auction 1"),
-    Lot("826a8ebb-8c9c-45b7-b08e-c784c442f55b", "4ac772c5-bc52-4d3c-ba9e-4010f511e175", "Lot 2 for auction 1"),
-    Lot("2e5faabf-47eb-40c1-a961-b1ca7e928b49", "4ac772c5-bc52-4d3c-ba9e-4010f511e175", "Lot 3 for auction 1")
+    Lot("6b2e9336-7911-4381-a0e7-382a4e510291".uuid, "4ac772c5-bc52-4d3c-ba9e-4010f511e175".uuid, "Lot 1 for auction 1"),
+    Lot("826a8ebb-8c9c-45b7-b08e-c784c442f55b".uuid, "4ac772c5-bc52-4d3c-ba9e-4010f511e175".uuid, "Lot 2 for auction 1"),
+    Lot("2e5faabf-47eb-40c1-a961-b1ca7e928b49".uuid, "4ac772c5-bc52-4d3c-ba9e-4010f511e175".uuid, "Lot 3 for auction 1")
   )
 
-  override def createAuction(data: AuctionData): VNel[AuctionId] = {
-    def _createAuction(data: String): AuctionId = {
-      val newId = newUUIDString
-      val auction = Auction(newId, data)
+  override def createAuction(data: AuctionData): VNel[UUID] = {
+    def _createAuction(data: String): UUID = {
+      val auction = Auction(newUUID, data)
       auctions :+= auction
-      newId
+      auction.id
     }
 
     Apply[VNel].apply(
@@ -36,16 +36,16 @@ class MemStorage extends AuctionService with InputValidator {
     }
   }
 
-  override def getAuction(id: AuctionId): VNel[Auction] = auctions.find( _.id == id).toSuccessNel(auctionNotFoundErrorMsg)
+  override def getAuction(id: UUID): VNel[Auction] = auctions.find( _.id.equals(id) ).toSuccessNel(auctionNotFoundErrorMsg)
 
-  override def addLot(auctionId: AuctionId, data: LotData): VNel[LotId] = {
+  override def addLot(auctionId: UUID, data: LotData): VNel[UUID] = {
     newLot(auctionId, data) map { lot =>
       lots :+= lot
       lot.id
     }
   }
 
-  override def getLots(auctionId: AuctionId, maybeLimit: Option[Int], maybeOffset: Option[Int]): LimitedResult[Lot] = {
+  override def getLots(auctionId: UUID, maybeLimit: Option[Int], maybeOffset: Option[Int]): LimitedResult[Lot] = {
     val limit = maybeLimit.getOrElse(10)
     val offset = maybeOffset.getOrElse(0)
 
@@ -54,18 +54,12 @@ class MemStorage extends AuctionService with InputValidator {
     LimitedResult(auctionLotsSlice, limit, offset, auctionLots.length)
   }
 
-  private def newUUIDString: String = UUID.randomUUID.toString
+  private def newUUID: UUID = UUID.randomUUID
 
-  private def newLot(auctionId: AuctionId, data: LotData): VNel[Lot] =
-    ((uuid(auctionId, auctionIdErrorMsg) andThen findAuction) |@| validData(data, lotDataErrorMsg)) { (_, _) =>
-      Lot(newUUIDString, auctionId, data)
+  private def newLot(auctionId: UUID, data: LotData): VNel[Lot] =
+    (getAuction(auctionId) |@| validData(data, lotDataErrorMsg)) { (_, _) =>
+      Lot(newUUID, auctionId, data)
     }
-
-  private def findAuction(uuid: UUID): VNel[Auction] = {
-    val stringUUID = uuid.toString
-    auctions.find( _.id == stringUUID).toSuccessNel(auctionNotFoundErrorMsg)
-  }
-
 }
 
 object MemStorage {

--- a/src/test/scala/AuctionsApiSpec.scala
+++ b/src/test/scala/AuctionsApiSpec.scala
@@ -7,6 +7,7 @@ import api.ErrorResponse.ErrorResponseMessage
 import api.ResponseUnmarshaller
 import entities.Auction
 import org.scalatest.{Matchers, WordSpec}
+import extensions.StringExtensions._
 
 import scala.util.Try
 
@@ -20,7 +21,7 @@ class AuctionsApiSpec extends WordSpec with Matchers with ScalatestRouteTest wit
       Get("/auctions/4ac772c5-bc52-4d3c-ba9e-4010f511e175") ~> auctionsApi ~> check {
         status shouldEqual StatusCodes.OK
         contentType shouldEqual ContentTypes.`application/json`
-        responseAs[Auction] shouldEqual Auction("4ac772c5-bc52-4d3c-ba9e-4010f511e175", "First")
+        responseAs[Auction] shouldEqual Auction("4ac772c5-bc52-4d3c-ba9e-4010f511e175".uuid, "First")
       }
     }
 
@@ -30,14 +31,9 @@ class AuctionsApiSpec extends WordSpec with Matchers with ScalatestRouteTest wit
       }
     }
 
-    "return 400 with error given wrong format of ID" in {
-      Get("/auctions/55555555-bc52") ~> sealedAuctionsApi ~> check {
-        status shouldEqual StatusCodes.BadRequest
-
-        val errors = responseAs[ErrorResponseMessage]._embedded
-        errors.length shouldBe 1
-
-        errors(0).message shouldEqual "requirement failed: Invalid auction Id. Auction Id must have a UUID format."
+    "return 404 not found given wrong format of ID" in {
+      Get("/auctions/asd__-bc52") ~> sealedAuctionsApi ~> check {
+        status shouldEqual StatusCodes.NotFound
       }
     }
 

--- a/src/test/scala/LotsApiSpec.scala
+++ b/src/test/scala/LotsApiSpec.scala
@@ -8,7 +8,7 @@ import api.ResponseUnmarshaller
 import entities.Lot
 import org.scalatest.{Matchers, WordSpec}
 import persistence.LimitedResult
-
+import extensions.StringExtensions._
 import scala.util.Try
 
 class LotsApiSpec extends WordSpec with Matchers with ScalatestRouteTest with Routes with ResponseUnmarshaller {
@@ -67,7 +67,7 @@ class LotsApiSpec extends WordSpec with Matchers with ScalatestRouteTest with Ro
         limitedResult.total shouldEqual 3
         limitedResult.items.length shouldEqual 1
 
-        limitedResult.items.head.id shouldEqual "2e5faabf-47eb-40c1-a961-b1ca7e928b49"
+        limitedResult.items.head.id shouldEqual "2e5faabf-47eb-40c1-a961-b1ca7e928b49".uuid
       }
     }
 
@@ -77,12 +77,10 @@ class LotsApiSpec extends WordSpec with Matchers with ScalatestRouteTest with Ro
       }
     }
 
-    "return a 400 with error given bad format of UUID" in {
+    "return a 405 with error given bad format of UUID" in {
       Get("/lots?auctionId=4ac772c5-bc52-4d3c") ~> sealedLotsApi ~> check {
-        status shouldEqual StatusCodes.BadRequest
-
-        val errors = responseAs[ErrorResponseMessage]._embedded
-        errors(0).message shouldEqual "Invalid auction Id. Please provide a valid UUID."
+        status shouldEqual StatusCodes.MethodNotAllowed
+        //TODO: are we OK with text/plain 405 error response?
       }
     }
 
@@ -108,14 +106,10 @@ class LotsApiSpec extends WordSpec with Matchers with ScalatestRouteTest with Ro
       val entity = HttpEntity(MediaTypes.`application/json`,
         "{\"auctionId\": \"721a27c386f6\", \"lotData\": \"    \"}")
 
-      Post("/lots").withEntity(entity) ~> lotsApi ~> check {
+      Post("/lots").withEntity(entity) ~> sealedLotsApi ~> check {
         status shouldEqual StatusCodes.BadRequest
 
-        val errors = responseAs[ErrorResponseMessage]._embedded
-        errors.length shouldBe 2
-
-        errors(0).message shouldEqual "Invalid auction Id. Please provide a valid UUID."
-        errors(1).message shouldEqual "Lot data cannot be empty."
+        //TODO: are we OK with text/plain 400 error response?
       }
     }
 


### PR DESCRIPTION
I think that the code complexity shrinked with a switch to UUID ids and it will also allow for easier transition to slick. There is one potential drawback though.

Switch from strings to UUIDs makes error responses different in some cases. One example would be that where we first accepted `.as[String]` every string would go in and after unsuccessful parsing to UUID we would send a `vnd.err` response. After changing that matcher to `.as[UUID]` strings that won't match UUID format will simply become a 405 , not allowed, as they won't match any path. I left a TODO in two places in tests to point out if we want it this way or is there some change required.

Additionally I have created a String extending method .uuid that will convert a string to a UUID object. It is only used for testing purposes (in tests and where we add dummy data to a `MemStorage`). The problem with this method is that the potential exception it can throw will be only catched at runtime. I wonder if we can make compiler check all the strings using this method. I think this could be solved with macros. What do you think @jczuchnowski ?